### PR TITLE
replaceMap doesn't work

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -295,7 +295,7 @@ Parser.prototype.getPackageName_ = function(name) {
   if (this.isInIgnorePackages_(name)) {
     return null;
   }
-  var name = this.replaceMethod_(name);
+  name = this.replaceMethod_(name);
   var names = name.split('.');
   if (this.isPrivateProp_(names)) {
     return null;
@@ -343,7 +343,7 @@ Parser.prototype.getPackageName_ = function(name) {
   }
 
   if (names.length > 1) {
-    return names.join('.');
+    return this.replaceMethod_(names.join('.'));
   } else {
     // Ignore just one word namespace like 'goog'.
     return null;

--- a/test/fixtures/parse/post-replace.js
+++ b/test/fixtures/parse/post-replace.js
@@ -1,0 +1,3 @@
+var NONE = goog.ui.KeyboardShortcutHandler.Modifiers.NONE;
+
+// toRequire: goog.ui.KeyboardShortcutHandler


### PR DESCRIPTION
--replaceMap=goog.ui.KeyboardShortcutHandler.Modifiers.NONE:goog.ui.KeyboardShortcutHandler.Modifiers

``` javascript
var NONE = goog.ui.KeyboardShortcutHandler.Modifiers.NONE;
/// toRequire: goog.ui.KeyboardShortcutHandler
```

`goog.disposeAll:goog.dispose` is working.
