### PR TITLE
Not insert unnecessary blank line.

### DIFF
--- a/lib/fix.js
+++ b/lib/fix.js
@@ -41,7 +41,7 @@ function getProvideRequireSrc(buf, info) {
     return "goog.require('" + namespace + "'); // fixclosure: suppressUnused";
   });
 
-  if (buf.length > 0 && toRequire.length + suppressed.length > 0) {
+  if (info.toProvide.length > 0 && toRequire.length + suppressed.length > 0) {
     buf.push('');
   }
 

--- a/test/cli.coffee
+++ b/test/cli.coffee
@@ -67,6 +67,15 @@ describe 'Command line', ->
     expected = fs.readFileSync('test/fixtures/cli/fix-no-provide.js.fixed.txt', encoding: 'utf8')
     fixedSrc.should.be.eql expected
 
+  it 'fix require-only but not enough requirements file', () ->
+    fs.copySync('test/fixtures/cli/fix-no-provide2.js', 'test/tmp/fix-no-provide2.js')
+    cli(cmd.concat(['test/tmp/fix-no-provide2.js', '--fix-in-place']), out, err, exit)
+    exit.calledOnce.should.be.false
+
+    fixedSrc = fs.readFileSync('test/tmp/fix-no-provide2.js', encoding: 'utf8')
+    expected = fs.readFileSync('test/fixtures/cli/fix-no-provide2.js.fixed.txt', encoding: 'utf8')
+    fixedSrc.should.be.eql expected
+
   it 'success if a package required with "suppress unused" is not used', () ->
     cli(cmd.concat(['test/fixtures/cli/suppress_unused.js', '--showSuccess']), out, err, exit)
     exit.calledOnce.should.be.false

--- a/test/fixtures/cli/fix-no-provide2.js
+++ b/test/fixtures/cli/fix-no-provide2.js
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview sample.
+ */
+goog.require('goog.foo');
+
+goog.foo.bar();
+goog.bar.baz();

--- a/test/fixtures/cli/fix-no-provide2.js.fixed.txt
+++ b/test/fixtures/cli/fix-no-provide2.js.fixed.txt
@@ -1,0 +1,8 @@
+/**
+ * @fileoverview sample.
+ */
+goog.require('goog.bar');
+goog.require('goog.foo');
+
+goog.foo.bar();
+goog.bar.baz();


### PR DESCRIPTION
Our test files are structured as follows.

``` js
/**
 * @fileoverview Unit test for my.app.SomeClass.
 */
goog.require('my.app.SomeClass');


describe('my.app.SomeClass', function() {
  // ...
});
```

In this case, fixclosure inserts a blank line between fileoverview JSDoc and `goog.require()`.
