### PR TITLE
Don't remove ignored provides.

### DIFF
--- a/lib/fix.js
+++ b/lib/fix.js
@@ -27,11 +27,33 @@ function fix(file, info) {
 }
 
 function getProvideRequireSrc(buf, info) {
-  info.toProvide.forEach(function(namespace) {
-    /*jshint quotmark:false */
-    buf.push("goog.provide('" + namespace + "');");
-  });
+  var allToProvide = getProvideSrc(info);
+  var allToRequire = getRequireSrc(info);
 
+  allToProvide.forEach(function(provide) {
+    buf.push(provide);
+  });
+  if (allToProvide.length > 0 && allToRequire.length > 0) {
+    buf.push('');
+  }
+  allToRequire.forEach(function(req) {
+    buf.push(req);
+  });
+}
+
+function getProvideSrc(info) {
+  var toProvide = info.toProvide.map(function(namespace) {
+    /*jshint quotmark:false */
+    return "goog.provide('" + namespace + "');";
+  });
+  var ignoredProvide = info.ignoredProvide.map(function(namespace) {
+    /*jshint quotmark:false */
+    return "goog.provide('" + namespace + "'); // fixclosure: ignore";
+  });
+  return toProvide.concat(ignoredProvide).sort();
+}
+
+function getRequireSrc(info) {
   var toRequire = info.toRequire.map(function(namespace) {
     /*jshint quotmark:false */
     return "goog.require('" + namespace + "');";
@@ -40,14 +62,7 @@ function getProvideRequireSrc(buf, info) {
     /*jshint quotmark:false */
     return "goog.require('" + namespace + "'); // fixclosure: ignore";
   });
-
-  if (info.toProvide.length > 0 && toRequire.length + ignoredRequire.length > 0) {
-    buf.push('');
-  }
-
-  toRequire.concat(ignoredRequire).sort().forEach(function(req) {
-    buf.push(req);
-  });
+  return toRequire.concat(ignoredRequire).sort();
 }
 
 module.exports = fix;

--- a/test/fixtures/cli/all-ng-types.js.fixed.txt
+++ b/test/fixtures/cli/all-ng-types.js.fixed.txt
@@ -1,4 +1,5 @@
 goog.provide('goog.provide.dup');
+goog.provide('goog.provide.ignore'); // fixclosure: ignore
 goog.provide('goog.provide.missing');
 
 goog.require('goog.require.dup');


### PR DESCRIPTION
README.md says:

> fixclosure doesn't remove any goog.provide and goog.require with this hint.

but fixclosure removes ignored `goog.provide`s.
