### PR TITLE
test(eslint): use eslint-plugin-node

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,17 @@
     "node": true
   },
   "extends": "eslint:recommended",
+  "plugins": ["node"],
   "rules": {
+    // eslint-plugin-node
+    "node/no-missing-import": 2,
+    "node/no-missing-require": 2,
+    "node/no-unpublished-import": 2,
+    "node/no-unpublished-require": 2,
+    "node/no-unsupported-features": [2, {"version": 0.10}],
+    "node/shebang": 2,
+
+    // builtin rules
     "accessor-pairs": "error",
     "array-bracket-spacing": "off",
     "array-callback-return": "off",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "coverage": "npm run coverage:test && npm run coverage:report",
     "ci": "npm run lint && npm run coverage"
   },
+  "files": [
+    "bin",
+    "lib"
+  ],
   "repository": "https://github.com/teppeis/fixclosure",
   "author": "Teppei Sato <teppeis@gmail.com>",
   "license": "MIT",
@@ -22,6 +26,7 @@
     "coffee-script": "^1.7.1",
     "coveralls": "^2.11.8",
     "eslint": "^2.3.0",
+    "eslint-plugin-node": "^1.0.0",
     "fs-extra": "^0.26.5",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",


### PR DESCRIPTION
This prevents #61.
Also, excluding test dir and dot-files from package.