### PR TITLE
feat: support goog.requireType() and goog.forwardDeclare()

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ Comma separated list.
 Replace method or property to namespace mapping like `goog.disposeAll:goog.dispose`.  
 Comma separated list of colon separated pairs like `foo.bar1:foo.bar2,foo.bar3:foo.bar4`.
 
+###  `--useForwardDeclare`
+
+Use `goog.forwardDeclare()` instead of `goog.requireType()` for types used only in JSDoc.
+Default: `false`
+
 ### `--showSuccess`
 
 Show not only failed files but also passed files.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -45,6 +45,11 @@ function setCommandOptions(command) {
       'Methods or properties to namespaces mapping like "before1:after1,before2:after2".',
       map
     )
+    .option(
+      '--useForwardDeclare',
+      'Use goog.forwardDeclare() instead of goog.requireType().',
+      false
+    )
     .option('--config <file>', '.fixclosurerc file path.')
     .option('--showSuccess', 'Show success ouput.', false)
     .option('--no-color', 'Disable color highlight.');
@@ -141,6 +146,11 @@ function main(argv, stdout, stderr, exit) {
     };
     const parser = new Parser(options);
     const info = parser.parse(src);
+
+    if (program.useForwardDeclare) {
+      info.toForwardDeclare = info.toRequireType;
+      info.toRequireType = [];
+    }
     log.info('Provided:');
     log.items(
       info.provided.map(item => item + (info.ignoredProvide.includes(item) ? ' (ignored)' : ''))
@@ -160,86 +170,41 @@ function main(argv, stdout, stderr, exit) {
       );
       log.info('');
     }
+    if (info.forwardDeclared.length > 0) {
+      log.info('ForwardDeclared:');
+      log.items(
+        info.forwardDeclared.map(
+          item => item + (info.ignoredForwardDeclare.includes(item) ? ' (ignored)' : '')
+        )
+      );
+      log.info('');
+    }
 
     let needToFix = false;
-
-    const dupProvide = getDuplicated(info.provided);
-    if (dupProvide.length > 0) {
-      needToFix = true;
-      log.error('Duplicated Provide:');
-      log.items(dupProvide);
-      log.info('');
-    }
-
-    const missingProvide = difference(info.toProvide, info.provided);
-    if (missingProvide.length > 0) {
-      needToFix = true;
-      log.error('Missing Provide:');
-      log.items(missingProvide);
-      log.info('');
-    }
-
-    let unnecessaryProvide = difference(info.provided, info.toProvide);
-    unnecessaryProvide = difference(unnecessaryProvide, info.ignoredProvide);
-    unnecessaryProvide = uniqArray(unnecessaryProvide);
-    if (unnecessaryProvide.length > 0) {
-      needToFix = true;
-      log.error('Unnecessary Provide:');
-      log.items(unnecessaryProvide);
-      log.info('');
-    }
-
-    const dupRequire = getDuplicated(info.required);
-    if (dupRequire.length > 0) {
-      needToFix = true;
-      log.error('Duplicated Require:');
-      log.items(dupRequire);
-      log.info('');
-    }
-
-    const missingRequire = difference(info.toRequire, info.required);
-    if (missingRequire.length > 0) {
-      needToFix = true;
-      log.error('Missing Require:');
-      log.items(missingRequire);
-      log.info('');
-    }
-
-    let unnecessaryRequire = difference(info.required, info.toRequire);
-    unnecessaryRequire = difference(unnecessaryRequire, info.ignoredRequire);
-    unnecessaryRequire = uniqArray(unnecessaryRequire);
-    if (unnecessaryRequire.length > 0) {
-      needToFix = true;
-      log.error('Unnecessary Require:');
-      log.items(unnecessaryRequire);
-      log.info('');
-    }
-
-    const dupRequireType = getDuplicated(info.requireTyped);
-    if (dupRequireType.length > 0) {
-      needToFix = true;
-      log.error('Duplicated RequireType:');
-      log.items(dupRequireType);
-      log.info('');
-    }
-
-    const missingRequireType = difference(info.toRequireType, info.requireTyped);
-    if (missingRequireType.length > 0) {
-      needToFix = true;
-      log.error('Missing RequireType:');
-      log.items(missingRequireType);
-      log.info('');
-    }
-
-    let unnecessaryRequireType = difference(info.requireTyped, info.toRequireType);
-    unnecessaryRequireType = difference(unnecessaryRequireType, info.ignoredRequireType);
-    unnecessaryRequireType = uniqArray(unnecessaryRequireType);
-    if (unnecessaryRequireType.length > 0) {
-      needToFix = true;
-      log.error('Unnecessary RequireType:');
-      log.items(unnecessaryRequireType);
-      log.info('');
-    }
+    needToFix =
+      checkDeclare(log, 'Provide', info.provided, info.toProvide, info.ignoredProvide) || needToFix;
+    needToFix =
+      checkDeclare(log, 'Require', info.required, info.toRequire, info.ignoredRequire) || needToFix;
+    needToFix =
+      checkDeclare(
+        log,
+        'RequireType',
+        info.requireTyped,
+        info.toRequireType,
+        info.ignoredRequireType,
+        info.forwardDeclared,
+        info.toForwardDeclare
+      ) || needToFix;
+    needToFix =
+      checkDeclare(
+        log,
+        'ForwardDeclare',
+        info.forwardDeclared,
+        info.toForwardDeclare,
+        info.ignoredForwardDeclare,
+        info.requireTyped,
+        info.toRequireType
+      ) || needToFix;
 
     if (needToFix) {
       if (program.fixInPlace) {
@@ -278,6 +243,41 @@ function main(argv, stdout, stderr, exit) {
     }
     log.flush(true);
   }
+}
+
+function checkDeclare(
+  log,
+  method,
+  declared,
+  toDeclare,
+  ignoredDeclare,
+  optionalDeclared = [],
+  optionalToDeclare = []
+) {
+  let needToFix = false;
+  const duplicated = getDuplicated(declared);
+  if (duplicated.length > 0) {
+    needToFix = true;
+    log.error(`Duplicated ${method}:`);
+    log.items(duplicated);
+    log.info('');
+  }
+  const missing = difference(toDeclare, declared, optionalDeclared);
+  if (missing.length > 0) {
+    needToFix = true;
+    log.error(`Missing ${method}:`);
+    log.items(missing);
+    log.info('');
+  }
+  let unnecessary = difference(declared, toDeclare, ignoredDeclare, optionalToDeclare);
+  unnecessary = uniqArray(unnecessary);
+  if (unnecessary.length > 0) {
+    needToFix = true;
+    log.error(`Unnecessary ${method}:`);
+    log.items(unnecessary);
+    log.info('');
+  }
+  return needToFix;
 }
 
 /**

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -206,6 +206,32 @@ function main(argv, stdout, stderr, exit) {
       log.info('');
     }
 
+    const dupRequireType = getDuplicated(info.requireTyped);
+    if (dupRequireType.length > 0) {
+      needToFix = true;
+      log.error('Duplicated RequireType:');
+      log.items(dupRequireType);
+      log.info('');
+    }
+
+    const missingRequireType = difference(info.toRequireType, info.requireTyped);
+    if (missingRequireType.length > 0) {
+      needToFix = true;
+      log.error('Missing RequireType:');
+      log.items(missingRequireType);
+      log.info('');
+    }
+
+    let unnecessaryRequireType = difference(info.requireTyped, info.toRequireType);
+    unnecessaryRequireType = difference(unnecessaryRequireType, info.ignoredRequireType);
+    unnecessaryRequireType = uniqArray(unnecessaryRequireType);
+    if (unnecessaryRequireType.length > 0) {
+      needToFix = true;
+      log.error('Unnecessary RequireType:');
+      log.items(unnecessaryRequireType);
+      log.info('');
+    }
+
     if (needToFix) {
       if (program.fixInPlace) {
         fix(file, info);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -151,6 +151,15 @@ function main(argv, stdout, stderr, exit) {
       info.required.map(item => item + (info.ignoredRequire.includes(item) ? ' (ignored)' : ''))
     );
     log.info('');
+    if (info.requireTyped.length > 0) {
+      log.info('RequireTyped:');
+      log.items(
+        info.requireTyped.map(
+          item => item + (info.ignoredRequireType.includes(item) ? ' (ignored)' : '')
+        )
+      );
+      log.info('');
+    }
 
     let needToFix = false;
 

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -36,20 +36,25 @@ function fix(file, info) {
  * @param {*} info
  */
 function writeDeclarationHeader(buf, info) {
-  const allToProvide = getProvideSrc(info);
-  const allToRequire = getRequireSrc(info);
-  const allToRequireType = getRequireTypeSrc(info);
+  const provides = getProvideSrc(info);
+  const requires = getRequireSrc(info);
+  const requireTypes = getRequireTypeSrc(info);
+  const forwardDeclares = getForwardDeclareSrc(info);
 
-  if (allToProvide.length > 0) {
-    buf.push(...allToProvide);
+  if (provides.length > 0) {
+    buf.push(...provides);
     buf.push('');
   }
-  if (allToRequire.length > 0) {
-    buf.push(...allToRequire);
+  if (requires.length > 0) {
+    buf.push(...requires);
     buf.push('');
   }
-  if (allToRequireType.length > 0) {
-    buf.push(...allToRequireType);
+  if (requireTypes.length > 0) {
+    buf.push(...requireTypes);
+    buf.push('');
+  }
+  if (forwardDeclares.length > 0) {
+    buf.push(...forwardDeclares);
     buf.push('');
   }
 }
@@ -76,6 +81,18 @@ function getRequireSrc(info) {
  */
 function getRequireTypeSrc(info) {
   return getDeclarationSrc(info.toRequireType, info.ignoredRequireType, 'goog.requireType');
+}
+
+/**
+ * @param {*} info
+ * @return {Array<string>}
+ */
+function getForwardDeclareSrc(info) {
+  return getDeclarationSrc(
+    info.toForwardDeclare,
+    info.ignoredForwardDeclare,
+    'goog.forwardDeclare'
+  );
 }
 
 /**

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -9,18 +9,21 @@ const fs = require('fs');
 function fix(file, info) {
   const buf = [];
   const src = fs.readFileSync(file, 'utf8');
+  let bodyStarted = false;
   if (info.provideEnd === 0) {
-    getProvideRequireSrc(buf, info);
-    buf.push('');
+    writeDeclarationHeader(buf, info);
     buf.push(src);
   } else {
     src.split('\n').forEach((line, index) => {
       const lineNum = index + 1;
-      if (lineNum === info.provideStart) {
-        getProvideRequireSrc(buf, info);
-      } else if (lineNum > info.provideStart && lineNum <= info.provideEnd) {
+      if (lineNum < info.provideStart) {
+        buf.push(line);
+      } else if (lineNum === info.provideStart) {
+        writeDeclarationHeader(buf, info);
+      } else if (lineNum <= info.provideEnd) {
         // skip
-      } else {
+      } else if (bodyStarted || line) {
+        bodyStarted = true;
         buf.push(line);
       }
     });
@@ -28,35 +31,63 @@ function fix(file, info) {
   fs.writeFileSync(file, buf.join('\n'), 'utf8');
 }
 
-function getProvideRequireSrc(buf, info) {
+/**
+ * @param {Array<string>} buf
+ * @param {*} info
+ */
+function writeDeclarationHeader(buf, info) {
   const allToProvide = getProvideSrc(info);
   const allToRequire = getRequireSrc(info);
+  const allToRequireType = getRequireTypeSrc(info);
 
-  allToProvide.forEach(provide => {
-    buf.push(provide);
-  });
-  if (allToProvide.length > 0 && allToRequire.length > 0) {
+  if (allToProvide.length > 0) {
+    buf.push(...allToProvide);
     buf.push('');
   }
-  allToRequire.forEach(req => {
-    buf.push(req);
-  });
+  if (allToRequire.length > 0) {
+    buf.push(...allToRequire);
+    buf.push('');
+  }
+  if (allToRequireType.length > 0) {
+    buf.push(...allToRequireType);
+    buf.push('');
+  }
 }
 
+/**
+ * @param {*} info
+ * @return {Array<string>}
+ */
 function getProvideSrc(info) {
-  const toProvide = info.toProvide.map(namespace => `goog.provide('${namespace}');`);
-  const ignoredProvide = info.ignoredProvide.map(
-    namespace => `goog.provide('${namespace}'); // fixclosure: ignore`
-  );
-  return toProvide.concat(ignoredProvide).sort();
+  return getDeclarationSrc(info.toProvide, info.ignoredProvide, 'goog.provide');
 }
 
+/**
+ * @param {*} info
+ * @return {Array<string>}
+ */
 function getRequireSrc(info) {
-  const toRequire = info.toRequire.map(namespace => `goog.require('${namespace}');`);
-  const ignoredRequire = info.ignoredRequire.map(
-    namespace => `goog.require('${namespace}'); // fixclosure: ignore`
-  );
-  return toRequire.concat(ignoredRequire).sort();
+  return getDeclarationSrc(info.toRequire, info.ignoredRequire, 'goog.require');
+}
+
+/**
+ * @param {*} info
+ * @return {Array<string>}
+ */
+function getRequireTypeSrc(info) {
+  return getDeclarationSrc(info.toRequireType, info.ignoredRequireType, 'goog.requireType');
+}
+
+/**
+ * @param {Array<string>} to
+ * @param {Array<string>} ignored
+ * @param {string} method like 'goog.require'
+ * @return {Array<string>}
+ */
+function getDeclarationSrc(to, ignored, method) {
+  const declarations = to.map(namespace => `${method}('${namespace}');`);
+  const ignores = ignored.map(namespace => `${method}('${namespace}'); // fixclosure: ignore`);
+  return declarations.concat(ignores).sort();
 }
 
 module.exports = fix;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -80,6 +80,8 @@ Parser.prototype.parse = function(src) {
   const parsed = this.parseAst_(program);
   const provided = this.extractProvided_(parsed);
   const required = this.extractRequired_(parsed);
+  const requireTyped = this.extractRequireTyped_(parsed);
+  const forwardDeclared = this.extractForwardDeclared_(parsed);
   const ignored = this.extractSuppressUnused_(parsed, program.comments);
   const toProvide = this.extractToProvide_(parsed, program.comments);
   const toRequire = this.extractToRequire_(parsed, toProvide, program.comments);
@@ -89,6 +91,8 @@ Parser.prototype.parse = function(src) {
   return {
     provided,
     required,
+    requireTyped,
+    forwardDeclared,
     toProvide,
     toRequire,
     toRequireType,
@@ -290,11 +294,7 @@ Parser.prototype.uniq_ = function(prev, cur) {
  * @private
  */
 Parser.prototype.extractProvided_ = function(parsed) {
-  return parsed
-    .filter(this.callExpFilter_.bind(this, 'goog.provide'))
-    .map(this.callExpMapper_)
-    .filter(this.isDefAndNotNull_)
-    .sort();
+  return this.extractGoogDeclaration_(parsed, 'goog.provide');
 };
 
 /**
@@ -303,8 +303,36 @@ Parser.prototype.extractProvided_ = function(parsed) {
  * @private
  */
 Parser.prototype.extractRequired_ = function(parsed) {
+  return this.extractGoogDeclaration_(parsed, 'goog.require');
+};
+
+/**
+ * @param {Array} parsed .
+ * @return {Array} .
+ * @private
+ */
+Parser.prototype.extractRequireTyped_ = function(parsed) {
+  return this.extractGoogDeclaration_(parsed, 'goog.requireType');
+};
+
+/**
+ * @param {Array} parsed .
+ * @return {Array} .
+ * @private
+ */
+Parser.prototype.extractForwardDeclared_ = function(parsed) {
+  return this.extractGoogDeclaration_(parsed, 'goog.forwardDeclare');
+};
+
+/**
+ * @param {Array} parsed .
+ * @param {string} method like 'goog.provide' or 'goog.require'
+ * @return {Array} .
+ * @private
+ */
+Parser.prototype.extractGoogDeclaration_ = function(parsed, method) {
   return parsed
-    .filter(this.callExpFilter_.bind(this, 'goog.require'))
+    .filter(this.callExpFilter_.bind(this, method))
     .map(this.callExpMapper_)
     .filter(this.isDefAndNotNull_)
     .sort();

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -82,14 +82,16 @@ Parser.prototype.parse = function(src) {
   const required = this.extractRequired_(parsed);
   const ignored = this.extractSuppressUnused_(parsed, program.comments);
   const toProvide = this.extractToProvide_(parsed, program.comments);
+  const toRequire = this.extractToRequire_(parsed, toProvide, program.comments);
   const toRequireFromJsDoc = this.extractToRequireFromJsDoc_(program.comments);
-  const toRequire = this.extractToRequire_(parsed, toProvide, program.comments, toRequireFromJsDoc);
+  const toRequireType = difference(toRequireFromJsDoc, toProvide, toRequire);
 
   return {
-    provided: provided,
-    required: required,
-    toProvide: toProvide,
-    toRequire: toRequire,
+    provided,
+    required,
+    toProvide,
+    toRequire,
+    toRequireType,
     ignoredProvide: ignored.provide,
     ignoredRequire: ignored.require,
     // first goog.provide or goog.require line
@@ -200,16 +202,13 @@ Parser.prototype.extractToRequireFromJsDoc_ = function(comments) {
         if (tag.title === 'implements' && tag.type.type === 'NameExpression') {
           prev.push(tag.type.name);
         }
-        if (
-          tag.title === 'extends' &&
-          tag.type.type === 'NameExpression' &&
-          this.containsJsDocTag_(jsdoc, 'interface')
-        ) {
+        if (tag.title === 'extends' && tag.type.type === 'NameExpression') {
           prev.push(tag.type.name);
         }
       });
       return prev;
-    }, []);
+    }, [])
+    .sort();
 };
 
 /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -98,6 +98,7 @@ Parser.prototype.parse = function(src) {
     toRequireType,
     ignoredProvide: ignored.provide,
     ignoredRequire: ignored.require,
+    ignoredRequireType: ignored.requireType,
     // first goog.provide or goog.require line
     provideStart: this.min_,
     // last goog.provide or goog.require line
@@ -255,23 +256,18 @@ Parser.prototype.extractSuppressUnused_ = function(parsed, comments) {
     return {provide: [], require: []};
   }
 
-  const ignoredProvide = parsed
-    .filter(this.callExpFilter_.bind(this, 'goog.provide'))
-    .filter(req => !!suppresses[req.node.loc.start.line])
-    .map(this.callExpMapper_)
-    .filter(this.isDefAndNotNull_)
-    .sort();
-
-  const ignoredRequire = parsed
-    .filter(this.callExpFilter_.bind(this, 'goog.require'))
-    .filter(req => !!suppresses[req.node.loc.start.line])
-    .map(this.callExpMapper_)
-    .filter(this.isDefAndNotNull_)
-    .sort();
+  const getSuppressedNamespaces = method =>
+    parsed
+      .filter(this.callExpFilter_.bind(this, method))
+      .filter(req => !!suppresses[req.node.loc.start.line])
+      .map(this.callExpMapper_)
+      .filter(this.isDefAndNotNull_)
+      .sort();
 
   return {
-    provide: ignoredProvide,
-    require: ignoredRequire,
+    provide: getSuppressedNamespaces('goog.provide'),
+    require: getSuppressedNamespaces('goog.require'),
+    requireType: getSuppressedNamespaces('goog.requireType'),
   };
 };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -253,7 +253,7 @@ Parser.prototype.extractSuppressUnused_ = function(parsed, comments) {
     }, {});
 
   if (Object.keys(suppresses).length === 0) {
-    return {provide: [], require: []};
+    return {provide: [], require: [], requireType: []};
   }
 
   const getSuppressedNamespaces = method =>

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -85,8 +85,8 @@ Parser.prototype.parse = function(src) {
   const ignored = this.extractSuppressUnused_(parsed, program.comments);
   const toProvide = this.extractToProvide_(parsed, program.comments);
   const toRequire = this.extractToRequire_(parsed, toProvide, program.comments);
-  const toRequireFromJsDoc = this.extractToRequireFromJsDoc_(program.comments);
-  const toRequireType = difference(toRequireFromJsDoc, toProvide, toRequire);
+  const toRequireTypwRaw = this.extractToRequireTypeFromJsDoc_(program.comments);
+  const toRequireType = difference(toRequireTypwRaw, toProvide, toRequire);
 
   return {
     provided,
@@ -96,9 +96,11 @@ Parser.prototype.parse = function(src) {
     toProvide,
     toRequire,
     toRequireType,
+    toForwardDeclare: [],
     ignoredProvide: ignored.provide,
     ignoredRequire: ignored.require,
     ignoredRequireType: ignored.requireType,
+    ignoredForwardDeclare: ignored.forwardDeclare,
     // first goog.provide or goog.require line
     provideStart: this.min_,
     // last goog.provide or goog.require line
@@ -194,7 +196,7 @@ Parser.prototype.extractToRequire_ = function(parsed, toProvide, comments, opt_r
  * @return {Array<string>} .
  * @private
  */
-Parser.prototype.extractToRequireFromJsDoc_ = function(comments) {
+Parser.prototype.extractToRequireTypeFromJsDoc_ = function(comments) {
   return comments
     .filter(
       comment =>
@@ -253,7 +255,7 @@ Parser.prototype.extractSuppressUnused_ = function(parsed, comments) {
     }, {});
 
   if (Object.keys(suppresses).length === 0) {
-    return {provide: [], require: [], requireType: []};
+    return {provide: [], require: [], requireType: [], forwardDeclare: []};
   }
 
   const getSuppressedNamespaces = method =>
@@ -268,6 +270,7 @@ Parser.prototype.extractSuppressUnused_ = function(parsed, comments) {
     provide: getSuppressedNamespaces('goog.provide'),
     require: getSuppressedNamespaces('goog.require'),
     requireType: getSuppressedNamespaces('goog.requireType'),
+    forwardDeclare: getSuppressedNamespaces('goog.forwardDeclare'),
   };
 };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -198,33 +198,31 @@ Parser.prototype.extractToRequireFromJsDoc_ = function(comments) {
     )
     .reduce((prev, comment) => {
       const jsdoc = doctrine.parse(`/* ${comment.value}*/`, {unwrap: true});
-      jsdoc.tags.forEach(tag => {
-        if (tag.title === 'implements' && tag.type.type === 'NameExpression') {
+      jsdoc.tags
+        .filter(
+          tag => tagsHavingType.has(tag.title) && tag.type && tag.type.type === 'NameExpression'
+        )
+        .forEach(tag => {
           prev.push(tag.type.name);
-        }
-        if (tag.title === 'extends' && tag.type.type === 'NameExpression') {
-          prev.push(tag.type.name);
-        }
-      });
+        });
       return prev;
     }, [])
-    .sort();
+    .filter(this.requireRootFilter_.bind(this))
+    .sort()
+    .reduce(this.uniq_, []);
 };
 
-/**
- * @param {!Object} jsdoc .
- * @param {string} tagName .
- * @return {boolean} .
- * @private
- */
-Parser.prototype.containsJsDocTag_ = function(jsdoc, tagName) {
-  for (const i in jsdoc.tags) {
-    if (jsdoc.tags[i].title === tagName) {
-      return true;
-    }
-  }
-  return false;
-};
+const tagsHavingType = new Set([
+  'const',
+  'define',
+  'enum',
+  'extends',
+  'implements',
+  'param',
+  'return',
+  'this',
+  'type',
+]);
 
 /**
  * Extract "goog.require('goog.foo') // fixclosure: ignore".

--- a/test/cli.js
+++ b/test/cli.js
@@ -55,9 +55,18 @@ describe('Command line', () => {
     cli(cmd.concat(['test/fixtures/cli/all-ng-types.js']), out, err, exit);
     exit.calledOnce.should.be.true;
     exit.firstCall.args.should.eql([1]);
-    const expected = fs.readFileSync('test/fixtures/cli/all-ng-types.js.error.txt', {
-      encoding: 'utf8',
-    });
+    const expected = fs.readFileSync('test/fixtures/cli/all-ng-types.js.error.txt', 'utf8');
+    err.toString().should.be.eql(expected);
+  });
+
+  it('output all error types with --useForwardDeclare', () => {
+    cli(cmd.concat(['test/fixtures/cli/all-ng-types.js', '--useForwardDeclare']), out, err, exit);
+    exit.calledOnce.should.be.true;
+    exit.firstCall.args.should.eql([1]);
+    const expected = fs.readFileSync(
+      'test/fixtures/cli/all-ng-types.js.forwarddeclare.error.txt',
+      'utf8'
+    );
     err.toString().should.be.eql(expected);
   });
 
@@ -219,10 +228,10 @@ describe('Command line', () => {
     });
 
     describe('--fix-in-place', () => {
-      const testFixInPlace = function(filename) {
+      const testFixInPlace = (filename, options = []) => {
         const tmppath = tempy.file(`test/tmp/${filename}`);
         fs.copyFileSync(`test/fixtures/cli/${filename}`, tmppath);
-        cli(cmd.concat([tmppath, '--fix-in-place']), out, err, exit);
+        cli(cmd.concat([tmppath, '--fix-in-place']).concat(options), out, err, exit);
         exit.calledOnce.should.be.false;
         const fixedSrc = fs.readFileSync(tmppath, {encoding: 'utf8'});
         const expected = fs.readFileSync(`test/fixtures/cli/${filename}.fixed.txt`, {
@@ -232,6 +241,9 @@ describe('Command line', () => {
       };
 
       it('fix in place all error types', () => testFixInPlace('all-ng-types.js'));
+
+      it('fix in place all error types with --useForwardDeclare', () =>
+        testFixInPlace('all-ng-types.js.forwarddeclare', ['--useForwardDeclare']));
 
       it('fix a file without provide', () => testFixInPlace('fix-no-provide.js'));
 

--- a/test/fixtures/cli/all-ng-types.js
+++ b/test/fixtures/cli/all-ng-types.js
@@ -8,10 +8,21 @@ goog.require('goog.require.dup');
 goog.require('goog.require.ignore'); // fixclosure: ignore
 goog.require('goog.require.unnecessary');
 
-goog.provide.dup.foo = function() {
+goog.requireType('goog.requireType.dup');
+goog.requireType('goog.requireType.dup');
+goog.requireType('goog.requireType.ignore'); // fixclosure: ignore
+goog.requireType('goog.requireType.unnecessary');
+
+/**
+ * @param {goog.requireType.dup} a
+ */
+goog.provide.dup.foo = function(a) {
     goog.require.dup.foo();
 };
 
-goog.provide.missing.foo = function() {
+/**
+ * @param {goog.requireType.missing} a
+ */
+goog.provide.missing.foo = function(a) {
     goog.require.missing.foo();
 };

--- a/test/fixtures/cli/all-ng-types.js.error.txt
+++ b/test/fixtures/cli/all-ng-types.js.error.txt
@@ -30,6 +30,15 @@ Missing Require:
 Unnecessary Require:
 - goog.require.unnecessary
 
+Duplicated RequireType:
+- goog.requireType.dup
+
+Missing RequireType:
+- goog.requireType.missing
+
+Unnecessary RequireType:
+- goog.requireType.unnecessary
+
 FAIL!
 
 1 of 1 files failed

--- a/test/fixtures/cli/all-ng-types.js.error.txt
+++ b/test/fixtures/cli/all-ng-types.js.error.txt
@@ -12,6 +12,12 @@ Required:
 - goog.require.ignore (ignored)
 - goog.require.unnecessary
 
+RequireTyped:
+- goog.requireType.dup
+- goog.requireType.dup
+- goog.requireType.ignore (ignored)
+- goog.requireType.unnecessary
+
 Duplicated Provide:
 - goog.provide.dup
 

--- a/test/fixtures/cli/all-ng-types.js.fixed.txt
+++ b/test/fixtures/cli/all-ng-types.js.fixed.txt
@@ -6,6 +6,10 @@ goog.require('goog.require.dup');
 goog.require('goog.require.ignore'); // fixclosure: ignore
 goog.require('goog.require.missing');
 
+goog.requireType('goog.requireType.dup');
+goog.requireType('goog.requireType.ignore'); // fixclosure: ignore
+goog.requireType('goog.requireType.missing');
+
 /**
  * @param {goog.requireType.dup} a
  */

--- a/test/fixtures/cli/all-ng-types.js.fixed.txt
+++ b/test/fixtures/cli/all-ng-types.js.fixed.txt
@@ -6,20 +6,27 @@ goog.require('goog.require.dup');
 goog.require('goog.require.ignore'); // fixclosure: ignore
 goog.require('goog.require.missing');
 
+goog.requireType('goog.forwardDeclare.dup');
+goog.requireType('goog.forwardDeclare.missing');
 goog.requireType('goog.requireType.dup');
 goog.requireType('goog.requireType.ignore'); // fixclosure: ignore
 goog.requireType('goog.requireType.missing');
 
+goog.forwardDeclare('goog.forwardDeclare.ignore'); // fixclosure: ignore
+
 /**
  * @param {goog.requireType.dup} a
+ * @param {goog.forwardDeclare.dup} b
+ * @param {goog.require.dup} c
  */
-goog.provide.dup.foo = function(a) {
+goog.provide.dup.foo = function(a, b, c) {
     goog.require.dup.foo();
 };
 
 /**
  * @param {goog.requireType.missing} a
+ * @param {goog.forwardDeclare.missing} b
  */
-goog.provide.missing.foo = function(a) {
+goog.provide.missing.foo = function(a, b) {
     goog.require.missing.foo();
 };

--- a/test/fixtures/cli/all-ng-types.js.fixed.txt
+++ b/test/fixtures/cli/all-ng-types.js.fixed.txt
@@ -6,10 +6,16 @@ goog.require('goog.require.dup');
 goog.require('goog.require.ignore'); // fixclosure: ignore
 goog.require('goog.require.missing');
 
-goog.provide.dup.foo = function() {
+/**
+ * @param {goog.requireType.dup} a
+ */
+goog.provide.dup.foo = function(a) {
     goog.require.dup.foo();
 };
 
-goog.provide.missing.foo = function() {
+/**
+ * @param {goog.requireType.missing} a
+ */
+goog.provide.missing.foo = function(a) {
     goog.require.missing.foo();
 };

--- a/test/fixtures/cli/all-ng-types.js.forwarddeclare
+++ b/test/fixtures/cli/all-ng-types.js.forwarddeclare
@@ -1,0 +1,1 @@
+all-ng-types.js

--- a/test/fixtures/cli/all-ng-types.js.forwarddeclare.error.txt
+++ b/test/fixtures/cli/all-ng-types.js.forwarddeclare.error.txt
@@ -45,15 +45,15 @@ Unnecessary Require:
 Duplicated RequireType:
 - goog.requireType.dup
 
-Missing RequireType:
-- goog.forwardDeclare.missing
-- goog.requireType.missing
-
 Unnecessary RequireType:
 - goog.requireType.unnecessary
 
 Duplicated ForwardDeclare:
 - goog.forwardDeclare.dup
+
+Missing ForwardDeclare:
+- goog.forwardDeclare.missing
+- goog.requireType.missing
 
 Unnecessary ForwardDeclare:
 - goog.forwardDeclare.unnecessary

--- a/test/fixtures/cli/all-ng-types.js.forwarddeclare.fixed.txt
+++ b/test/fixtures/cli/all-ng-types.js.forwarddeclare.fixed.txt
@@ -1,22 +1,18 @@
 goog.provide('goog.provide.dup');
-goog.provide('goog.provide.dup');
 goog.provide('goog.provide.ignore'); // fixclosure: ignore
-goog.provide('goog.provide.unnecessary');
+goog.provide('goog.provide.missing');
 
-goog.require('goog.require.dup');
 goog.require('goog.require.dup');
 goog.require('goog.require.ignore'); // fixclosure: ignore
-goog.require('goog.require.unnecessary');
+goog.require('goog.require.missing');
 
-goog.requireType('goog.requireType.dup');
-goog.requireType('goog.requireType.dup');
 goog.requireType('goog.requireType.ignore'); // fixclosure: ignore
-goog.requireType('goog.requireType.unnecessary');
 
-goog.forwardDeclare('goog.forwardDeclare.dup');
 goog.forwardDeclare('goog.forwardDeclare.dup');
 goog.forwardDeclare('goog.forwardDeclare.ignore'); // fixclosure: ignore
-goog.forwardDeclare('goog.forwardDeclare.unnecessary');
+goog.forwardDeclare('goog.forwardDeclare.missing');
+goog.forwardDeclare('goog.requireType.dup');
+goog.forwardDeclare('goog.requireType.missing');
 
 /**
  * @param {goog.requireType.dup} a

--- a/test/fixtures/parse/@const.js
+++ b/test/fixtures/parse/@const.js
@@ -1,0 +1,6 @@
+/**
+ * @const {goog.ui.Component}
+ */
+var foo;
+
+// toRequireType: goog.ui.Component

--- a/test/fixtures/parse/@define.js
+++ b/test/fixtures/parse/@define.js
@@ -1,0 +1,4 @@
+/** @define {goog.ui.Component} */
+var foo;
+
+// toRequireType: goog.ui.Component

--- a/test/fixtures/parse/@enum.js
+++ b/test/fixtures/parse/@enum.js
@@ -1,0 +1,6 @@
+/**
+ * @enum {goog.ui.Component}
+ */
+var Foo = {};
+
+// toRequireType: goog.ui.Component

--- a/test/fixtures/parse/@extends-required.js
+++ b/test/fixtures/parse/@extends-required.js
@@ -1,0 +1,9 @@
+/**
+ * @constructor
+ * @extends {goog.Disposable}
+ */
+var Bar = function() {
+};
+goog.inherits(Bar, goog.Disposable);
+
+// toRequire: goog.Disposable

--- a/test/fixtures/parse/@extends.js
+++ b/test/fixtures/parse/@extends.js
@@ -1,6 +1,4 @@
 /**
- * A base of an interface should be required.
- *
  * @interface
  * @extends {goog.disposable.IDisposable}
  */
@@ -8,12 +6,11 @@ var Foo = function() {
 };
 
 /**
- * A base of a class should be required.
- *
  * @constructor
  * @extends {goog.Disposable}
  */
 var Bar = function() {
 };
 
-// toRequire: goog.disposable.IDisposable
+// toRequireType: goog.Disposable
+// toRequireType: goog.disposable.IDisposable

--- a/test/fixtures/parse/@implements.js
+++ b/test/fixtures/parse/@implements.js
@@ -13,6 +13,6 @@ var Foo = function() {
 var Bar = function() {
 };
 
-// toRequire: goog.disposable.IDisposable
-// toRequire: goog.fx.Transition
-// toRequire: goog.fx.anim.Animated
+// toRequireType: goog.disposable.IDisposable
+// toRequireType: goog.fx.Transition
+// toRequireType: goog.fx.anim.Animated

--- a/test/fixtures/parse/@param.js
+++ b/test/fixtures/parse/@param.js
@@ -1,0 +1,7 @@
+/**
+ * @param {goog.ui.Component} component
+ */
+function foo(component) {
+};
+
+// toRequireType: goog.ui.Component

--- a/test/fixtures/parse/@return.js
+++ b/test/fixtures/parse/@return.js
@@ -1,0 +1,7 @@
+/**
+ * @return {goog.ui.Component}
+ */
+var foo = function() {
+};
+
+// toRequireType: goog.ui.Component

--- a/test/fixtures/parse/@this.js
+++ b/test/fixtures/parse/@this.js
@@ -1,0 +1,7 @@
+/**
+ * @this {goog.ui.Component}
+ */
+var foo = function() {
+};
+
+// toRequireType: goog.ui.Component

--- a/test/fixtures/parse/@type.js
+++ b/test/fixtures/parse/@type.js
@@ -1,0 +1,13 @@
+/**
+ * @type {goog.ui.Component}
+ */
+var foo;
+
+/**
+ * Uniqued
+ *
+ * @type {goog.ui.Component}
+ */
+var bar;
+
+// toRequireType: goog.ui.Component

--- a/test/fixtures/parse/forwarddeclare.js
+++ b/test/fixtures/parse/forwarddeclare.js
@@ -1,0 +1,5 @@
+goog.forwardDeclare('goog.foo1');
+goog.forwardDeclare('goog.foo2');
+
+// forwardDeclared: goog.foo1
+// forwardDeclared: goog.foo2

--- a/test/fixtures/parse/requiretype.js
+++ b/test/fixtures/parse/requiretype.js
@@ -1,0 +1,5 @@
+goog.requireType('goog.foo1');
+goog.requireType('goog.foo2');
+
+// requireTyped: goog.foo1
+// requireTyped: goog.foo2

--- a/test/lib/asserts.js
+++ b/test/lib/asserts.js
@@ -20,6 +20,18 @@ exports.assertFile = (file, options) => {
     required.push(matches[1]);
   }
 
+  regex = /^\/\/ requireTyped: (.*)/gm;
+  const requireTyped = [];
+  while ((matches = regex.exec(src)) !== null) {
+    requireTyped.push(matches[1]);
+  }
+
+  regex = /^\/\/ forwardDeclared: (.*)/gm;
+  const forwardDeclared = [];
+  while ((matches = regex.exec(src)) !== null) {
+    forwardDeclared.push(matches[1]);
+  }
+
   regex = /^\/\/ toProvide: (.*)/gm;
   const toProvide = [];
   while ((matches = regex.exec(src)) !== null) {
@@ -55,6 +67,8 @@ exports.assertFile = (file, options) => {
   // info.should.have.keys ['provided', 'required', 'toProvide', 'toRequire']
   info.provided.should.be.eql(provided);
   info.required.should.be.eql(required);
+  info.requireTyped.should.be.eql(requireTyped);
+  info.forwardDeclared.should.be.eql(forwardDeclared);
   info.toProvide.should.be.eql(toProvide);
   info.toRequire.should.be.eql(toRequire);
   info.toRequireType.should.be.eql(toRequireType);

--- a/test/lib/asserts.js
+++ b/test/lib/asserts.js
@@ -32,6 +32,12 @@ exports.assertFile = (file, options) => {
     toRequire.push(matches[1]);
   }
 
+  regex = /^\/\/ toRequireType: (.*)/gm;
+  const toRequireType = [];
+  while ((matches = regex.exec(src)) !== null) {
+    toRequireType.push(matches[1]);
+  }
+
   regex = /^\/\/ ignoredProvide: (.*)/gm;
   const ignoredProvide = [];
   while ((matches = regex.exec(src)) !== null) {
@@ -51,6 +57,7 @@ exports.assertFile = (file, options) => {
   info.required.should.be.eql(required);
   info.toProvide.should.be.eql(toProvide);
   info.toRequire.should.be.eql(toRequire);
+  info.toRequireType.should.be.eql(toRequireType);
   info.ignoredProvide.should.be.eql(ignoredProvide);
   info.ignoredRequire.should.be.eql(ignoredRequire);
 };


### PR DESCRIPTION
- report required types used only in JSDoc as errors
- handle `goog.requireType()` and `goog.forwardDeclare()`
- fix errors around them
- add `--useForwardDeclare` CLI option
- remove two or more blank lines between declaration headers and body

BREAKING CHANGE: Types used only in JSDoc are reported as errors.
Previously only types of `@extends` in `@interface` are reported.