### PR TITLE
fix: TypeError: cli is not a function

### DIFF
--- a/bin/fixclosure.js
+++ b/bin/fixclosure.js
@@ -2,6 +2,6 @@
 'use strict';
 
 (async () => {
-  const cli = require('../lib/cli');
+  const { cli } = require('../lib/cli');
   await cli(process.argv, process.stdout, process.stderr, process.exit);
 })();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib .tsbuildinfo .nyc_output coverage",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint --ext js,ts src test",
-    "test": "run-s clean lint unit:coverage build",
+    "test": "run-s clean lint build unit:coverage",
     "unit": "mocha",
     "unit:coverage": "nyc --reporter=html --reporter=text mocha"
   },

--- a/test/bin.ts
+++ b/test/bin.ts
@@ -1,0 +1,16 @@
+import assert from "assert";
+import { spawnSync } from "child_process";
+import fs from "fs";
+
+describe("bin/fixclosure", () => {
+  it("should be able to execute fixclosure", () => {
+    const result = spawnSync("node", [
+      "bin/fixclosure.js",
+      "--no-color",
+      "test/fixtures/bin/ng.js",
+    ]);
+    const actual = result.stderr.toString();
+    const expected = fs.readFileSync("test/fixtures/bin/ng.js.txt").toString();
+    assert.strictEqual(actual, expected);
+  });
+});

--- a/test/fixtures/bin/ng.js
+++ b/test/fixtures/bin/ng.js
@@ -1,0 +1,11 @@
+goog.provide('goog.bar');
+
+goog.require('goog.baz');
+
+goog.bar.bar1 = function() {
+  goog.baz.baz1();
+};
+
+goog.bar.bar2 = function() {
+  goog.baz.baz2();
+};

--- a/test/fixtures/bin/ng.js.txt
+++ b/test/fixtures/bin/ng.js.txt
@@ -1,0 +1,16 @@
+File: test/fixtures/bin/ng.js
+
+Provided:
+- goog.bar
+
+Required:
+- goog.baz
+
+Unnecessary Require:
+- goog.baz
+
+FAIL!
+
+Total: 1 files
+Passed: 0 files
+Failed: 1 files


### PR DESCRIPTION
Currently, `fixclosure` command throws the error as follows.

```
TypeError: cli is not a function
```

I've fixed the error and added a test for `fixclosure` command!