### PR TITLE
Also require "extends" tags

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -226,7 +226,7 @@ export class Parser {
             toRequireType.push(...names);
           });
         tags
-          .filter(tag => tag.title === "implements" && tag.type)
+          .filter(tag => (tag.title === "implements" || tag.title === "extends") && tag.type)
           .map(tag => this.extractType(tag.type!))
           .forEach(names => {
             toRequire.push(...names);

--- a/test/fixtures/parse/@extends.js
+++ b/test/fixtures/parse/@extends.js
@@ -12,5 +12,5 @@ var Foo = function() {
 var Bar = function() {
 };
 
-// toRequireType: goog.Bar
-// toRequireType: goog.Foo
+// toRequire: goog.Bar
+// toRequire: goog.Foo


### PR DESCRIPTION
If an interface extends another interface, those types should also be required.