### PR TITLE
Allow comments in jsDoc.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -229,7 +229,10 @@ export class Parser {
           isBlockComment(comment) && /^\*/.test(comment.value)
       )
       .forEach(comment => {
-        const { tags } = doctrine.parse(`/*${comment.value}*/`, { unwrap: true });
+        const { tags } = doctrine.parse(`/*${comment.value}*/`, {
+          unwrap: true,
+          recoverable: true,
+        });
         tags
           .filter(tag => tagsHavingType.has(tag.title) && tag.type)
           .map(tag => this.extractType(tag.type!))

--- a/test/fixtures/parse/@extends.js
+++ b/test/fixtures/parse/@extends.js
@@ -1,6 +1,7 @@
 /**
  * @interface
  * @extends {goog.Foo}
+ * I am a comment
  */
 var Foo = function() {
 };


### PR DESCRIPTION
When a comment was encountered, the previous tag was not parsed by doctrine. Setting `recovarable: true` fixes the issue.

Fixes #278 